### PR TITLE
Add support for DisplayId and UrlFormat

### DIFF
--- a/src/Particular.Obsoletes.Attributes/ObsoleteMetadataAttribute.cs
+++ b/src/Particular.Obsoletes.Attributes/ObsoleteMetadataAttribute.cs
@@ -54,7 +54,7 @@ public sealed class ObsoleteMetadataAttribute : Attribute
     /// </para>
     /// <para>
     /// Use <c>{0}</c> when the URL page slug matches the diagnostic ID, for example a documentation site:
-    /// <c>DiagnosticId = "NSB0001"</c> with <c>UrlFormat = "https://docs.particular.net/obsoletions/{0}"</c> produces <c>https://docs.particular.net/obsoletions/NSB0001</c>.
+    /// <c>DiagnosticId = "NSB0001"</c> with <c>UrlFormat = "https://docs.particular.net/r/obsoletions/{0}"</c> produces <c>https://docs.particular.net/r/obsoletions/NSB0001</c>.
     /// </para>
     /// <para>
     /// Use a literal URL (no <c>{0}</c>) when linking directly to a specific GitHub issue,

--- a/src/Particular.Obsoletes.Attributes/ObsoleteMetadataAttribute.cs
+++ b/src/Particular.Obsoletes.Attributes/ObsoleteMetadataAttribute.cs
@@ -29,4 +29,39 @@ public sealed class ObsoleteMetadataAttribute : Attribute
     /// The version when the obsolete member will be removed. Must be convertible to a <see cref="Version"/>.
     /// </summary>
     public string? RemoveInVersion { get; set; }
+
+    /// <summary>
+    /// The diagnostic ID to associate with the obsolete warning. Follows the convention of a short repository prefix followed by a zero-padded number, e.g. "NSB0001".
+    /// This enables consumers to suppress the warning independently using <c>#pragma warning disable</c> or <c>&lt;NoWarn&gt;</c> with the specified ID,
+    /// rather than the default <c>CS0618</c>.
+    /// When set, this is propagated to the DiagnosticId property of the <see cref="ObsoleteAttribute" />.
+    /// </summary>
+    public string? DiagnosticId { get; set; }
+
+    /// <summary>
+    /// The URL for the help link that appears in IDE tooltips and build warnings.
+    /// Can point to any documentation URL, such as a docs page or a GitHub issue.
+    /// Can be used with or without <see cref="DiagnosticId" />; the two properties are independent.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When the format string contains the placeholder <c>{0}</c>, the compiler substitutes the diagnostic ID into it.
+    /// If <see cref="DiagnosticId" /> is set, that value is used; otherwise the compiler falls back to the default obsolete diagnostic ID (<c>CS0618</c>).
+    /// The placeholder receives the <b>entire</b> diagnostic ID string, not just the numeric portion.
+    /// </para>
+    /// <para>
+    /// When the format string does <b>not</b> contain <c>{0}</c>, it is treated as a literal URL and used as-is.
+    /// </para>
+    /// <para>
+    /// Use <c>{0}</c> when the URL page slug matches the diagnostic ID, for example a documentation site:
+    /// <c>DiagnosticId = "NSB0001"</c> with <c>UrlFormat = "https://docs.particular.net/obsoletions/{0}"</c> produces <c>https://docs.particular.net/obsoletions/NSB0001</c>.
+    /// </para>
+    /// <para>
+    /// Use a literal URL (no <c>{0}</c>) when linking directly to a specific GitHub issue,
+    /// because GitHub issue URLs require a plain integer and the placeholder would receive the full diagnostic ID (e.g. <c>NSB0001</c>) instead of the issue number:
+    /// <c>UrlFormat = "https://github.com/Particular/NServiceBus/issues/42"</c>.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="DiagnosticId" />
+    public string? UrlFormat { get; set; }
 }

--- a/src/Particular.Obsoletes.Fixes/ObsoleteCodeFixProvider.cs
+++ b/src/Particular.Obsoletes.Fixes/ObsoleteCodeFixProvider.cs
@@ -16,7 +16,9 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
             DiagnosticIds.MissingObsoleteAttribute,
             DiagnosticIds.ObsoleteAttributeMissingConstructorArguments,
             DiagnosticIds.IncorrectObsoleteAttributeMessageArgument,
-            DiagnosticIds.IncorrectObsoleteAttributeErrorArgument
+            DiagnosticIds.IncorrectObsoleteAttributeErrorArgument,
+            DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument,
+            DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument
         ];
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -27,6 +29,8 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
         {
             diagnostic.Properties.TryGetValue("Message", out var message);
             diagnostic.Properties.TryGetValue("Error", out var error);
+            diagnostic.Properties.TryGetValue("DiagnosticId", out var diagnosticId);
+            diagnostic.Properties.TryGetValue("UrlFormat", out var urlFormat);
 
             message ??= string.Empty;
             error ??= string.Empty;
@@ -36,14 +40,14 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
                 case DiagnosticIds.MissingObsoleteAttribute:
                     {
                         var title = "Add missing Obsolete attribute";
-                        var codeAction = CodeAction.Create(title, token => AddMissingObsoleteAttribute(context.Document, diagnostic.Location, message, error, token), title);
+                        var codeAction = CodeAction.Create(title, token => AddMissingObsoleteAttribute(context.Document, diagnostic.Location, message, error, diagnosticId, urlFormat, token), title);
                         context.RegisterCodeFix(codeAction, diagnostic);
                         break;
                     }
                 case DiagnosticIds.ObsoleteAttributeMissingConstructorArguments:
                     {
                         var title = "Add missing attribute arguments";
-                        var codeAction = CodeAction.Create(title, token => AddMissingConstructorArguments(context.Document, diagnostic.Location, message, error, token), title);
+                        var codeAction = CodeAction.Create(title, token => AddMissingConstructorArguments(context.Document, diagnostic.Location, message, error, diagnosticId, urlFormat, token), title);
                         context.RegisterCodeFix(codeAction, diagnostic);
                         break;
                     }
@@ -61,6 +65,20 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
                         context.RegisterCodeFix(codeAction, diagnostic);
                         break;
                     }
+                case DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument:
+                    {
+                        var title = "Fix incorrect DiagnosticId argument";
+                        var codeAction = CodeAction.Create(title, token => FixIncorrectObsoleteAttributeDiagnosticIdArgument(context.Document, diagnostic.Location, diagnosticId, token), title);
+                        context.RegisterCodeFix(codeAction, diagnostic);
+                        break;
+                    }
+                case DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument:
+                    {
+                        var title = "Fix incorrect UrlFormat argument";
+                        var codeAction = CodeAction.Create(title, token => FixIncorrectObsoleteAttributeUrlFormatArgument(context.Document, diagnostic.Location, urlFormat, token), title);
+                        context.RegisterCodeFix(codeAction, diagnostic);
+                        break;
+                    }
 
                 default:
                     break;
@@ -70,7 +88,7 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
         return Task.CompletedTask;
     }
 
-    static async Task<Document> AddMissingObsoleteAttribute(Document document, Location location, string message, string error, CancellationToken cancellationToken)
+    static async Task<Document> AddMissingObsoleteAttribute(Document document, Location location, string message, string error, string? diagnosticId, string? urlFormat, CancellationToken cancellationToken)
     {
         if (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) is not { } root ||
             root.FindNode(location.SourceSpan) is not { Parent.Parent: { } member } ||
@@ -83,7 +101,7 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
         var generator = SyntaxGenerator.GetGenerator(document);
 
         var obsoleteAttributeTypeNode = generator.TypeExpression(obsoleteAttributeTypeSymbol).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
-        var obsoleteAttributeNode = generator.Attribute(obsoleteAttributeTypeNode, [generator.AttributeArgument(generator.LiteralExpression(message)), generator.AttributeArgument(generator.LiteralExpression(bool.Parse(error)))]);
+        var obsoleteAttributeNode = generator.Attribute(obsoleteAttributeTypeNode, BuildAttributeArguments(generator, message, error, diagnosticId, urlFormat));
 
         var newMemberNode = generator.AddAttributes(member, obsoleteAttributeNode);
         var newRoot = generator.ReplaceNode(root, member, newMemberNode);
@@ -92,7 +110,7 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
         return newDocument;
     }
 
-    static async Task<Document> AddMissingConstructorArguments(Document document, Location location, string message, string error, CancellationToken cancellationToken)
+    static async Task<Document> AddMissingConstructorArguments(Document document, Location location, string message, string error, string? diagnosticId, string? urlFormat, CancellationToken cancellationToken)
     {
         if (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) is not { } root ||
             root.FindNode(location.SourceSpan) is not AttributeSyntax original ||
@@ -105,12 +123,33 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
         var generator = SyntaxGenerator.GetGenerator(document);
 
         var obsoleteAttributeTypeNode = generator.TypeExpression(obsoleteAttributeTypeSymbol).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
-        var obsoleteAttributeNode = generator.Attribute(obsoleteAttributeTypeNode, [generator.AttributeArgument(generator.LiteralExpression(message)), generator.AttributeArgument(generator.LiteralExpression(bool.Parse(error)))]);
+        var obsoleteAttributeNode = generator.Attribute(obsoleteAttributeTypeNode, BuildAttributeArguments(generator, message, error, diagnosticId, urlFormat));
 
         var newRoot = generator.ReplaceNode(root, original, obsoleteAttributeNode);
         var newDocument = document.WithSyntaxRoot(newRoot);
 
         return newDocument;
+    }
+
+    static List<SyntaxNode> BuildAttributeArguments(SyntaxGenerator generator, string message, string error, string? diagnosticId, string? urlFormat)
+    {
+        var arguments = new List<SyntaxNode>
+        {
+            generator.AttributeArgument(generator.LiteralExpression(message)),
+            generator.AttributeArgument(generator.LiteralExpression(bool.Parse(error)))
+        };
+
+        if (!string.IsNullOrEmpty(diagnosticId))
+        {
+            arguments.Add(generator.AttributeArgument("DiagnosticId", generator.LiteralExpression(diagnosticId)));
+        }
+
+        if (!string.IsNullOrEmpty(urlFormat))
+        {
+            arguments.Add(generator.AttributeArgument("UrlFormat", generator.LiteralExpression(urlFormat)));
+        }
+
+        return arguments;
     }
 
     static Task<Document> FixIncorrectObsoleteAttributeMessageArgument(Document document, Location location, string message, CancellationToken cancellationToken) => FixIncorrectObsoleteAttributeArgument(document, location, generator => generator.LiteralExpression(message), cancellationToken);
@@ -131,5 +170,52 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
         var newDocument = document.WithSyntaxRoot(newRoot);
 
         return newDocument;
+    }
+
+    static Task<Document> FixIncorrectObsoleteAttributeDiagnosticIdArgument(Document document, Location location, string? diagnosticId, CancellationToken cancellationToken)
+        => FixIncorrectObsoleteAttributeNamedArgument(document, location, "DiagnosticId", diagnosticId, cancellationToken);
+
+    static Task<Document> FixIncorrectObsoleteAttributeUrlFormatArgument(Document document, Location location, string? urlFormat, CancellationToken cancellationToken)
+        => FixIncorrectObsoleteAttributeNamedArgument(document, location, "UrlFormat", urlFormat, cancellationToken);
+
+    static async Task<Document> FixIncorrectObsoleteAttributeNamedArgument(Document document, Location location, string name, string? value, CancellationToken cancellationToken)
+    {
+        if (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) is not { } root)
+        {
+            return document;
+        }
+
+        var node = root.FindNode(location.SourceSpan);
+        var generator = SyntaxGenerator.GetGenerator(document);
+
+        // Case 1: location points to the named argument itself (replace value or remove)
+        if (node is AttributeArgumentSyntax existingArg && existingArg.NameEquals?.Name.Identifier.ValueText == name)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                var updatedRoot = generator.RemoveNode(root, existingArg);
+                return updatedRoot is not null ? document.WithSyntaxRoot(updatedRoot) : document;
+            }
+
+            var newArg = generator.AttributeArgument(name, generator.LiteralExpression(value));
+            var newRoot = generator.ReplaceNode(root, existingArg, newArg);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        // Case 2: location points to the Obsolete attribute (add the named argument)
+        if (node is AttributeSyntax attr)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return document;
+            }
+
+            var newArg = generator.AttributeArgument(name, generator.LiteralExpression(value));
+            var newAttr = generator.AddAttributeArguments(attr, [newArg]);
+            var newRoot = generator.ReplaceNode(root, attr, newAttr);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        return document;
     }
 }

--- a/src/Particular.Obsoletes.Fixes/ObsoleteCodeFixProvider.cs
+++ b/src/Particular.Obsoletes.Fixes/ObsoleteCodeFixProvider.cs
@@ -18,7 +18,9 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
             DiagnosticIds.IncorrectObsoleteAttributeMessageArgument,
             DiagnosticIds.IncorrectObsoleteAttributeErrorArgument,
             DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument,
-            DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument
+            DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument,
+            DiagnosticIds.MissingObsoleteAttributeDiagnosticIdArgument,
+            DiagnosticIds.MissingObsoleteAttributeUrlFormatArgument
         ];
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -75,6 +77,20 @@ public class ObsoleteCodeFixProvider : CodeFixProvider
                 case DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument:
                     {
                         var title = "Fix incorrect UrlFormat argument";
+                        var codeAction = CodeAction.Create(title, token => FixIncorrectObsoleteAttributeUrlFormatArgument(context.Document, diagnostic.Location, urlFormat, token), title);
+                        context.RegisterCodeFix(codeAction, diagnostic);
+                        break;
+                    }
+                case DiagnosticIds.MissingObsoleteAttributeDiagnosticIdArgument:
+                    {
+                        var title = "Add missing DiagnosticId argument";
+                        var codeAction = CodeAction.Create(title, token => FixIncorrectObsoleteAttributeDiagnosticIdArgument(context.Document, diagnostic.Location, diagnosticId, token), title);
+                        context.RegisterCodeFix(codeAction, diagnostic);
+                        break;
+                    }
+                case DiagnosticIds.MissingObsoleteAttributeUrlFormatArgument:
+                    {
+                        var title = "Add missing UrlFormat argument";
                         var codeAction = CodeAction.Create(title, token => FixIncorrectObsoleteAttributeUrlFormatArgument(context.Document, diagnostic.Location, urlFormat, token), title);
                         context.RegisterCodeFix(codeAction, diagnostic);
                         break;

--- a/src/Particular.Obsoletes/DiagnosticDescriptors.cs
+++ b/src/Particular.Obsoletes/DiagnosticDescriptors.cs
@@ -131,4 +131,20 @@ public static class DiagnosticDescriptors
         category: "Code",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor MissingObsoleteAttributeDiagnosticIdArgument = new(
+        id: DiagnosticIds.MissingObsoleteAttributeDiagnosticIdArgument,
+        title: "Obsolete attributes should have a DiagnosticId value that matches the ObsoleteMetadata attribute",
+        messageFormat: "The Obsolete attribute is missing the DiagnosticId value specified in the ObsoleteMetadata attribute",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor MissingObsoleteAttributeUrlFormatArgument = new(
+        id: DiagnosticIds.MissingObsoleteAttributeUrlFormatArgument,
+        title: "Obsolete attributes should have a UrlFormat value that matches the ObsoleteMetadata attribute",
+        messageFormat: "The Obsolete attribute is missing the UrlFormat value specified in the ObsoleteMetadata attribute",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Particular.Obsoletes/DiagnosticDescriptors.cs
+++ b/src/Particular.Obsoletes/DiagnosticDescriptors.cs
@@ -91,4 +91,36 @@ public static class DiagnosticDescriptors
         category: "Code",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IncorrectObsoleteAttributeDiagnosticIdArgument = new(
+        id: DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument,
+        title: "Obsolete attributes should have a DiagnosticId value that matches the ObsoleteMetadata attribute",
+        messageFormat: "The Obsolete attribute's DiagnosticId value does not match the information specified in the ObsoleteMetadata attribute",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IncorrectObsoleteAttributeUrlFormatArgument = new(
+        id: DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument,
+        title: "Obsolete attributes should have a UrlFormat value that matches the ObsoleteMetadata attribute",
+        messageFormat: "The Obsolete attribute's UrlFormat value does not match the information specified in the ObsoleteMetadata attribute",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor InvalidDiagnosticId = new(
+        id: DiagnosticIds.InvalidDiagnosticId,
+        title: "DiagnosticId should not be empty or contain whitespace",
+        messageFormat: "The value specified for DiagnosticId '{0}' is empty or contains whitespace, which prevents it from being used with #pragma warning disable or NoWarn",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor InvalidUrlFormat = new(
+        id: DiagnosticIds.InvalidUrlFormat,
+        title: "UrlFormat should contain at most one placeholder",
+        messageFormat: "The value specified for UrlFormat '{0}' contains more than one placeholder. The compiler will ignore UrlFormat when multiple placeholders are present.",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Particular.Obsoletes/DiagnosticDescriptors.cs
+++ b/src/Particular.Obsoletes/DiagnosticDescriptors.cs
@@ -123,4 +123,12 @@ public static class DiagnosticDescriptors
         category: "Code",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UrlFormatPlaceholderRequiresDiagnosticId = new(
+        id: DiagnosticIds.UrlFormatPlaceholderRequiresDiagnosticId,
+        title: "UrlFormat with placeholder requires DiagnosticId",
+        messageFormat: "The UrlFormat '{0}' contains a placeholder but no DiagnosticId is specified. The compiler will substitute the default 'CS0618', which is unlikely to produce a valid URL.",
+        category: "Code",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Particular.Obsoletes/DiagnosticIds.cs
+++ b/src/Particular.Obsoletes/DiagnosticIds.cs
@@ -23,4 +23,5 @@ public static class DiagnosticIds
     public const string IncorrectObsoleteAttributeUrlFormatArgument = Prefix + "0013";
     public const string InvalidDiagnosticId = Prefix + "0014";
     public const string InvalidUrlFormat = Prefix + "0015";
+    public const string UrlFormatPlaceholderRequiresDiagnosticId = Prefix + "0016";
 }

--- a/src/Particular.Obsoletes/DiagnosticIds.cs
+++ b/src/Particular.Obsoletes/DiagnosticIds.cs
@@ -24,4 +24,6 @@ public static class DiagnosticIds
     public const string InvalidDiagnosticId = Prefix + "0014";
     public const string InvalidUrlFormat = Prefix + "0015";
     public const string UrlFormatPlaceholderRequiresDiagnosticId = Prefix + "0016";
+    public const string MissingObsoleteAttributeDiagnosticIdArgument = Prefix + "0017";
+    public const string MissingObsoleteAttributeUrlFormatArgument = Prefix + "0018";
 }

--- a/src/Particular.Obsoletes/DiagnosticIds.cs
+++ b/src/Particular.Obsoletes/DiagnosticIds.cs
@@ -19,4 +19,8 @@ public static class DiagnosticIds
     public const string ObsoleteAttributeMissingConstructorArguments = Prefix + "0009";
     public const string IncorrectObsoleteAttributeMessageArgument = Prefix + "0010";
     public const string IncorrectObsoleteAttributeErrorArgument = Prefix + "0011";
+    public const string IncorrectObsoleteAttributeDiagnosticIdArgument = Prefix + "0012";
+    public const string IncorrectObsoleteAttributeUrlFormatArgument = Prefix + "0013";
+    public const string InvalidDiagnosticId = Prefix + "0014";
+    public const string InvalidUrlFormat = Prefix + "0015";
 }

--- a/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
+++ b/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
@@ -41,6 +41,10 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             DiagnosticDescriptors.ObsoleteAttributeMissingConstructorArguments,
             DiagnosticDescriptors.IncorrectObsoleteAttributeMessageArgument,
             DiagnosticDescriptors.IncorrectObsoleteAttributeErrorArgument,
+            DiagnosticDescriptors.IncorrectObsoleteAttributeDiagnosticIdArgument,
+            DiagnosticDescriptors.IncorrectObsoleteAttributeUrlFormatArgument,
+            DiagnosticDescriptors.InvalidDiagnosticId,
+            DiagnosticDescriptors.InvalidUrlFormat,
         ];
 
     public override void Initialize(AnalysisContext context)
@@ -161,6 +165,26 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        var hasInvalidDiagnosticId = values.DiagnosticIdSet && string.IsNullOrWhiteSpace(values.DiagnosticId);
+        var hasInvalidUrlFormat = values.UrlFormatSet && CountFormatPlaceholders(values.UrlFormat) > 1;
+
+        if (hasInvalidDiagnosticId)
+        {
+            var attributeArgument = GetAttributeArgumentSyntax(obsoleteMetadataAttributeArguments, nameof(values.DiagnosticId));
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.InvalidDiagnosticId, CreateLocation(attributeArgument), values.DiagnosticId));
+        }
+
+        if (hasInvalidUrlFormat)
+        {
+            var attributeArgument = GetAttributeArgumentSyntax(obsoleteMetadataAttributeArguments, nameof(values.UrlFormat));
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.InvalidUrlFormat, CreateLocation(attributeArgument), values.UrlFormat));
+        }
+
+        if (hasInvalidDiagnosticId || hasInvalidUrlFormat)
+        {
+            return;
+        }
+
         var expectedMessage = BuildMessage(assemblyVersion, values.Message, values.ReplacementTypeOrMember, treatAsErrorFromVersion, removeInVersion);
         var expectedError = assemblyVersion >= treatAsErrorFromVersion;
 
@@ -168,6 +192,8 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
         {
             { "Message", expectedMessage },
             { "Error", expectedError.ToString() },
+            { "DiagnosticId", values.DiagnosticIdSet ? values.DiagnosticId : null },
+            { "UrlFormat", values.UrlFormatSet ? values.UrlFormat : null },
         }.ToImmutableDictionary();
 
         if (obsoleteAttribute is null)
@@ -193,6 +219,41 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
         if (actualError != expectedError)
         {
             context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeErrorArgument, CreateLocation(obsoleteAttributeArguments?[1]), properties));
+        }
+
+        var expectedDiagnosticId = values.DiagnosticIdSet ? values.DiagnosticId : null;
+        var expectedUrlFormat = values.UrlFormatSet ? values.UrlFormat : null;
+        string? actualDiagnosticId = null;
+        string? actualUrlFormat = null;
+
+        foreach (var argument in obsoleteAttribute.NamedArguments)
+        {
+            if (argument.Key == "DiagnosticId")
+            {
+                actualDiagnosticId = argument.Value.Value?.ToString();
+            }
+            else if (argument.Key == "UrlFormat")
+            {
+                actualUrlFormat = argument.Value.Value?.ToString();
+            }
+        }
+
+        if (actualDiagnosticId != expectedDiagnosticId)
+        {
+            var diagnosticIdArgument = GetAttributeArgumentSyntax(obsoleteAttributeArguments, "DiagnosticId");
+            var diagnosticIdLocation = diagnosticIdArgument is not null
+                ? CreateLocation(diagnosticIdArgument)
+                : CreateLocation(obsoleteAttribute.ApplicationSyntaxReference);
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeDiagnosticIdArgument, diagnosticIdLocation, properties));
+        }
+
+        if (actualUrlFormat != expectedUrlFormat)
+        {
+            var urlFormatArgument = GetAttributeArgumentSyntax(obsoleteAttributeArguments, "UrlFormat");
+            var urlFormatLocation = urlFormatArgument is not null
+                ? CreateLocation(urlFormatArgument)
+                : CreateLocation(obsoleteAttribute.ApplicationSyntaxReference);
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeUrlFormatArgument, urlFormatLocation, properties));
         }
     }
 
@@ -224,6 +285,10 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
         string? removeInVersion = null;
         bool removeInVersionSet = false;
         string? replacementTypeOrMember = null;
+        string? diagnosticId = null;
+        bool diagnosticIdSet = false;
+        string? urlFormat = null;
+        bool urlFormatSet = false;
 
         foreach (var argument in obsoleteMetadataAttribute.NamedArguments)
         {
@@ -245,9 +310,19 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             {
                 replacementTypeOrMember = argument.Value.Value?.ToString();
             }
+            else if (argument.Key == "DiagnosticId")
+            {
+                diagnosticId = argument.Value.Value?.ToString();
+                diagnosticIdSet = true;
+            }
+            else if (argument.Key == "UrlFormat")
+            {
+                urlFormat = argument.Value.Value?.ToString();
+                urlFormatSet = true;
+            }
         }
 
-        return new ObsoleteMetadataAttributeValues(message, treatAsErrorFromVersion, treatAsErrorFromVersionSet, removeInVersion, removeInVersionSet, replacementTypeOrMember);
+        return new ObsoleteMetadataAttributeValues(message, treatAsErrorFromVersion, treatAsErrorFromVersionSet, removeInVersion, removeInVersionSet, replacementTypeOrMember, diagnosticId, diagnosticIdSet, urlFormat, urlFormatSet);
     }
 
     static AttributeArgumentSyntax? GetAttributeArgumentSyntax(SeparatedSyntaxList<AttributeArgumentSyntax>? attributeArguments, string argumentName)
@@ -302,6 +377,32 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
         }
 
         return Version.TryParse(input, out result);
+    }
+
+    static int CountFormatPlaceholders(string? format)
+    {
+        if (format is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        var remaining = format.AsSpan();
+
+        while (remaining.Length > 0)
+        {
+            var index = remaining.IndexOf(Placeholder);
+
+            if (index < 0)
+            {
+                break;
+            }
+
+            count++;
+            remaining = remaining.Slice(index + Placeholder.Length);
+        }
+
+        return count;
     }
 
     static Location CreateLocation(SyntaxReference? syntaxReference) => CreateLocation(syntaxReference?.SyntaxTree, syntaxReference?.Span);
@@ -369,4 +470,5 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
     }
 
     static ReadOnlySpan<char> Dot => ".";
+    static ReadOnlySpan<char> Placeholder => "{0}";
 }

--- a/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
+++ b/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
@@ -200,8 +200,8 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
         {
             { "Message", expectedMessage },
             { "Error", expectedError.ToString() },
-            { "DiagnosticId", values.DiagnosticIdSet ? values.DiagnosticId : null },
-            { "UrlFormat", values.UrlFormatSet ? values.UrlFormat : null },
+            { "DiagnosticId", values.DiagnosticId },
+            { "UrlFormat", values.UrlFormat },
         }.ToImmutableDictionary();
 
         if (obsoleteAttribute is null)
@@ -229,8 +229,8 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeErrorArgument, CreateLocation(obsoleteAttributeArguments?[1]), properties));
         }
 
-        var expectedDiagnosticId = values.DiagnosticIdSet ? values.DiagnosticId : null;
-        var expectedUrlFormat = values.UrlFormatSet ? values.UrlFormat : null;
+        var expectedDiagnosticId = values.DiagnosticId;
+        var expectedUrlFormat = values.UrlFormat;
         string? actualDiagnosticId = null;
         string? actualUrlFormat = null;
 

--- a/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
+++ b/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
@@ -45,6 +45,7 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             DiagnosticDescriptors.IncorrectObsoleteAttributeUrlFormatArgument,
             DiagnosticDescriptors.InvalidDiagnosticId,
             DiagnosticDescriptors.InvalidUrlFormat,
+            DiagnosticDescriptors.UrlFormatPlaceholderRequiresDiagnosticId,
         ];
 
     public override void Initialize(AnalysisContext context)
@@ -167,6 +168,7 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
 
         var hasInvalidDiagnosticId = values.DiagnosticIdSet && string.IsNullOrWhiteSpace(values.DiagnosticId);
         var hasInvalidUrlFormat = values.UrlFormatSet && CountFormatPlaceholders(values.UrlFormat) > 1;
+        var hasUrlFormatPlaceholderWithoutDiagnosticId = values.UrlFormatSet && !values.DiagnosticIdSet && CountFormatPlaceholders(values.UrlFormat) == 1;
 
         if (hasInvalidDiagnosticId)
         {
@@ -180,7 +182,13 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.InvalidUrlFormat, CreateLocation(attributeArgument), values.UrlFormat));
         }
 
-        if (hasInvalidDiagnosticId || hasInvalidUrlFormat)
+        if (hasUrlFormatPlaceholderWithoutDiagnosticId)
+        {
+            var attributeArgument = GetAttributeArgumentSyntax(obsoleteMetadataAttributeArguments, nameof(values.UrlFormat));
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.UrlFormatPlaceholderRequiresDiagnosticId, CreateLocation(attributeArgument), values.UrlFormat));
+        }
+
+        if (hasInvalidDiagnosticId || hasInvalidUrlFormat || hasUrlFormatPlaceholderWithoutDiagnosticId)
         {
             return;
         }

--- a/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
+++ b/src/Particular.Obsoletes/ObsoleteAnalyzer.cs
@@ -46,6 +46,8 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
             DiagnosticDescriptors.InvalidDiagnosticId,
             DiagnosticDescriptors.InvalidUrlFormat,
             DiagnosticDescriptors.UrlFormatPlaceholderRequiresDiagnosticId,
+            DiagnosticDescriptors.MissingObsoleteAttributeDiagnosticIdArgument,
+            DiagnosticDescriptors.MissingObsoleteAttributeUrlFormatArgument,
         ];
 
     public override void Initialize(AnalysisContext context)
@@ -248,20 +250,34 @@ public class ObsoleteAnalyzer : DiagnosticAnalyzer
 
         if (actualDiagnosticId != expectedDiagnosticId)
         {
-            var diagnosticIdArgument = GetAttributeArgumentSyntax(obsoleteAttributeArguments, "DiagnosticId");
-            var diagnosticIdLocation = diagnosticIdArgument is not null
-                ? CreateLocation(diagnosticIdArgument)
-                : CreateLocation(obsoleteAttribute.ApplicationSyntaxReference);
-            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeDiagnosticIdArgument, diagnosticIdLocation, properties));
+            if (actualDiagnosticId is null && expectedDiagnosticId is not null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.MissingObsoleteAttributeDiagnosticIdArgument, CreateLocation(obsoleteAttribute.ApplicationSyntaxReference), properties));
+            }
+            else
+            {
+                var diagnosticIdArgument = GetAttributeArgumentSyntax(obsoleteAttributeArguments, "DiagnosticId");
+                var diagnosticIdLocation = diagnosticIdArgument is not null
+                    ? CreateLocation(diagnosticIdArgument)
+                    : CreateLocation(obsoleteAttribute.ApplicationSyntaxReference);
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeDiagnosticIdArgument, diagnosticIdLocation, properties));
+            }
         }
 
         if (actualUrlFormat != expectedUrlFormat)
         {
-            var urlFormatArgument = GetAttributeArgumentSyntax(obsoleteAttributeArguments, "UrlFormat");
-            var urlFormatLocation = urlFormatArgument is not null
-                ? CreateLocation(urlFormatArgument)
-                : CreateLocation(obsoleteAttribute.ApplicationSyntaxReference);
-            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeUrlFormatArgument, urlFormatLocation, properties));
+            if (actualUrlFormat is null && expectedUrlFormat is not null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.MissingObsoleteAttributeUrlFormatArgument, CreateLocation(obsoleteAttribute.ApplicationSyntaxReference), properties));
+            }
+            else
+            {
+                var urlFormatArgument = GetAttributeArgumentSyntax(obsoleteAttributeArguments, "UrlFormat");
+                var urlFormatLocation = urlFormatArgument is not null
+                    ? CreateLocation(urlFormatArgument)
+                    : CreateLocation(obsoleteAttribute.ApplicationSyntaxReference);
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.IncorrectObsoleteAttributeUrlFormatArgument, urlFormatLocation, properties));
+            }
         }
     }
 

--- a/src/Particular.Obsoletes/ObsoleteMetadataAttributeValues.cs
+++ b/src/Particular.Obsoletes/ObsoleteMetadataAttributeValues.cs
@@ -1,3 +1,3 @@
 ﻿namespace Particular.Obsoletes;
 
-readonly record struct ObsoleteMetadataAttributeValues(string? Message, string? TreatAsErrorFromVersion, bool TreatAsErrorFromVersionSet, string? RemoveInVersion, bool RemoveInVersionSet, string? ReplacementTypeOrMember);
+readonly record struct ObsoleteMetadataAttributeValues(string? Message, string? TreatAsErrorFromVersion, bool TreatAsErrorFromVersionSet, string? RemoveInVersion, bool RemoveInVersionSet, string? ReplacementTypeOrMember, string? DiagnosticId, bool DiagnosticIdSet, string? UrlFormat, bool UrlFormatSet);

--- a/src/Tests/ObsoleteAnalyzerTests.cs
+++ b/src/Tests/ObsoleteAnalyzerTests.cs
@@ -404,7 +404,7 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
     }
 
     [Test]
-    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_Missing()
+    public Task MissingObsoleteAttributeDiagnosticIdArgument()
     {
         var code = """
         [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
@@ -415,7 +415,7 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
         }
         """;
 
-        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument);
+        return Assert(code, DiagnosticIds.MissingObsoleteAttributeDiagnosticIdArgument);
     }
 
     [Test]
@@ -451,7 +451,7 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
     }
 
     [Test]
-    public Task IncorrectObsoleteAttributeUrlFormatArgument_Missing()
+    public Task MissingObsoleteAttributeUrlFormatArgument()
     {
         var code = """
         [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
@@ -462,7 +462,7 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
         }
         """;
 
-        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument);
+        return Assert(code, DiagnosticIds.MissingObsoleteAttributeUrlFormatArgument);
     }
 
     [Test]

--- a/src/Tests/ObsoleteAnalyzerTests.cs
+++ b/src/Tests/ObsoleteAnalyzerTests.cs
@@ -343,8 +343,8 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
         var code = """
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
 
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         public class Foo
         {
 
@@ -439,7 +439,7 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
     public Task IncorrectObsoleteAttributeUrlFormatArgument_WrongValue()
     {
         var code = """
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", [|UrlFormat = "https://wrong.com/{0}"|])]
         public class Foo
         {
@@ -528,7 +528,7 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
     public Task UrlFormatPlaceholderRequiresDiagnosticId()
     {
         var code = """
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", [|UrlFormat = "https://docs.particular.net/obsoletions/{0}"|])]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", [|UrlFormat = "https://docs.particular.net/r/obsoletions/{0}"|])]
         public class Foo
         {
 

--- a/src/Tests/ObsoleteAnalyzerTests.cs
+++ b/src/Tests/ObsoleteAnalyzerTests.cs
@@ -336,4 +336,191 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
 
         return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeErrorArgument);
     }
+
+    [Test]
+    public Task NoErrors_WithDiagnosticIdAndTemplateUrlFormat()
+    {
+        var code = """
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code);
+    }
+
+    [Test]
+    public Task NoErrors_WithLiteralUrlFormat_WithoutDiagnosticId()
+    {
+        var code = """
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code);
+    }
+
+    [Test]
+    public Task NoErrors_WithDiagnosticIdAndLiteralUrlFormat()
+    {
+        var code = """
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_WrongValue()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, [|DiagnosticId = "WRONG"|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_Missing()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
+        [[|Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false)|]]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_ExtraOnObsolete()
+    {
+        var code = """
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, [|DiagnosticId = "NSB0001"|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeDiagnosticIdArgument);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeUrlFormatArgument_WrongValue()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, [|UrlFormat = "https://wrong.com/{0}"|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeUrlFormatArgument_Missing()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        [[|Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false)|]]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeUrlFormatArgument_ExtraOnObsolete()
+    {
+        var code = """
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, [|UrlFormat = "https://github.com/Particular/NServiceBus/issues/42"|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.IncorrectObsoleteAttributeUrlFormatArgument);
+    }
+
+    [Test]
+    public Task InvalidDiagnosticId_Empty()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", [|DiagnosticId = ""|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.InvalidDiagnosticId);
+    }
+
+    [Test]
+    public Task InvalidDiagnosticId_Whitespace()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", [|DiagnosticId = " "|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.InvalidDiagnosticId);
+    }
+
+    [Test]
+    public Task InvalidUrlFormat_MultiplePlaceholders()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", [|UrlFormat = "https://example.com/{0}/{0}"|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.InvalidUrlFormat);
+    }
 }

--- a/src/Tests/ObsoleteAnalyzerTests.cs
+++ b/src/Tests/ObsoleteAnalyzerTests.cs
@@ -439,8 +439,8 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
     public Task IncorrectObsoleteAttributeUrlFormatArgument_WrongValue()
     {
         var code = """
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, [|UrlFormat = "https://wrong.com/{0}"|])]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", [|UrlFormat = "https://wrong.com/{0}"|])]
         public class Foo
         {
 
@@ -522,5 +522,19 @@ public class ObsoleteAnalyzerTests : AnalyzerTestFixture<ObsoleteAnalyzer>
         """;
 
         return Assert(code, DiagnosticIds.InvalidUrlFormat);
+    }
+
+    [Test]
+    public Task UrlFormatPlaceholderRequiresDiagnosticId()
+    {
+        var code = """
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", [|UrlFormat = "https://docs.particular.net/obsoletions/{0}"|])]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(code, DiagnosticIds.UrlFormatPlaceholderRequiresDiagnosticId);
     }
 }

--- a/src/Tests/ObsoleteCodeFixProviderTests.cs
+++ b/src/Tests/ObsoleteCodeFixProviderTests.cs
@@ -354,7 +354,7 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
     }
 
     [Test]
-    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_Missing()
+    public Task MissingObsoleteAttributeDiagnosticIdArgument()
     {
         var original = """
         using System;
@@ -450,7 +450,7 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
     }
 
     [Test]
-    public Task IncorrectObsoleteAttributeUrlFormatArgument_Missing()
+    public Task MissingObsoleteAttributeUrlFormatArgument()
     {
         var original = """
         using System;

--- a/src/Tests/ObsoleteCodeFixProviderTests.cs
+++ b/src/Tests/ObsoleteCodeFixProviderTests.cs
@@ -425,7 +425,7 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://wrong.com/{0}")]
         public class Foo
         {

--- a/src/Tests/ObsoleteCodeFixProviderTests.cs
+++ b/src/Tests/ObsoleteCodeFixProviderTests.cs
@@ -235,7 +235,7 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         public class Foo
         {
 
@@ -247,8 +247,8 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be removed in version 3.0.0.", true, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
+        [Obsolete("Will be removed in version 3.0.0.", true, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         public class Foo
         {
 
@@ -297,7 +297,7 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         [Obsolete]
         public class Foo
         {
@@ -310,8 +310,8 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         public class Foo
         {
 
@@ -438,8 +438,8 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         public class Foo
         {
 
@@ -521,7 +521,7 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "WRONG", UrlFormat = "https://wrong.com/{0}")]
         public class Foo
         {
@@ -534,8 +534,8 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/r/obsoletions/{0}")]
         public class Foo
         {
 

--- a/src/Tests/ObsoleteCodeFixProviderTests.cs
+++ b/src/Tests/ObsoleteCodeFixProviderTests.cs
@@ -226,4 +226,322 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
 
         return Assert(original, expected);
     }
+
+    [Test]
+    public Task MissingObsolete_WithDiagnosticIdAndTemplateUrlFormat()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be removed in version 3.0.0.", true, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task MissingObsolete_WithLiteralUrlFormatWithoutDiagnosticId()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        [Obsolete("Will be removed in version 3.0.0.", true, UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task MissingConstructorArguments_WithDiagnosticIdAndTemplateUrlFormat()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_WrongValue()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "WRONG")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_Missing()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false)]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdArgument_ExtraOnObsolete()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false)]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeUrlFormatArgument_WrongValue()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://wrong.com/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeUrlFormatArgument_Missing()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false)]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeUrlFormatArgument_ExtraOnObsolete()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://github.com/Particular/NServiceBus/issues/42")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false)]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
+
+    [Test]
+    public Task IncorrectObsoleteAttributeDiagnosticIdAndUrlFormatArguments_BothWrong()
+    {
+        var original = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "WRONG", UrlFormat = "https://wrong.com/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        var expected = """
+        using System;
+        using Particular.Obsoletes;
+
+        [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        public class Foo
+        {
+
+        }
+        """;
+
+        return Assert(original, expected);
+    }
 }

--- a/src/Tests/ObsoleteCodeFixProviderTests.cs
+++ b/src/Tests/ObsoleteCodeFixProviderTests.cs
@@ -425,8 +425,8 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://wrong.com/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://wrong.com/{0}")]
         public class Foo
         {
 
@@ -438,8 +438,8 @@ public class ObsoleteCodeFixProviderTests : CodeFixTestFixture<ObsoleteAnalyzer,
         using Particular.Obsoletes;
 
         [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
-        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
-        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [ObsoleteMetadata(TreatAsErrorFromVersion = "2", RemoveInVersion = "3", DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
+        [Obsolete("Will be treated as an error from version 2.0.0. Will be removed in version 3.0.0.", false, DiagnosticId = "NSB0001", UrlFormat = "https://docs.particular.net/obsoletions/{0}")]
         public class Foo
         {
 


### PR DESCRIPTION
## What

Adds `DiagnosticId` and `UrlFormat` as optional properties on `ObsoleteMetadataAttribute`. The analyzer and code fix provider automatically propagate them to the generated `[Obsolete]` attribute.

## Why

Since .NET 5, `ObsoleteAttribute` supports `DiagnosticId` and `UrlFormat` for stable suppression IDs and clickable help links in IDE tooltips and build output. We had to work around it by manually adding them to the `[Obsolete]` attribute, outside the metadata-driven validation and code fixing the package provides.

## What it enables

- Set `DiagnosticId` and `UrlFormat` on `ObsoleteMetadata`, and the fixer generates them on the `[Obsolete]` attribute automatically
- `DiagnosticId` follows the convention of a short repository prefix followed by a zero-padded number (e.g. `NSB0001`), so consumers can suppress warnings with `#pragma warning disable NSB0001` or `<NoWarn>` instead of the generic `CS0618`
- `UrlFormat` supports two patterns:
  - **Template URL** with `{0}` — the compiler substitutes the diagnostic ID, useful when the URL slug matches the ID (e.g. `https://docs.particular.net/obsoletions/{0}`)
  - **Literal URL** without `{0}` — used as-is, useful for direct links to specific resources like GitHub issues (e.g. `https://github.com/Particular/NServiceBus/issues/42`)
- The two properties are independent — either, both, or neither can be set

## Validation

Two new diagnostics catch metadata mistakes that would otherwise fail silently:

- `OBSOLETES0014` — `DiagnosticId` is empty or contains whitespace, which breaks `#pragma`/`NoWarn` suppression
- `OBSOLETES0015` — `UrlFormat` contains more than one `{0}` placeholder, because the compiler silently ignores the entire URL in that case

## What's missing

We don't yet have support for `DiagnosticId` and `UrlFormat` using a placeholder in the docs engine. The template URL pattern (`https://docs.particular.net/obsoletions/{0}`) needs a docs page per diagnostic ID, which doesn't exist yet. I'll raise that as a separate feature request so the docs engine can serve those pages.